### PR TITLE
Update facebook-commerce-events-tracker.php

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -208,14 +208,22 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				return;
 			}
 
+			// Ensure posts is a plain array for PHP 8+
+			$__fbwoo_items = $wp_query->posts;
+			if ($__fbwoo_items instanceof \Timber\PostQuery) {
+				$__fbwoo_items = $__fbwoo_items->posts; // Timber\PostQuery → array
+			} elseif ($__fbwoo_items instanceof \Traversable) {
+				$__fbwoo_items = iterator_to_array($__fbwoo_items);
+			}
 			$products = array_values(
 				array_map(
 					function ( $post ) {
 						return wc_get_product( $post );
 					},
-					$wp_query->posts
+					is_array($__fbwoo_items) ? $__fbwoo_items : []
 				)
 			);
+
 
 			// if any product is a variant, fire the pixel with
 			// content_type: product_group


### PR DESCRIPTION
Fix PHP 8+ TypeError: array_map(): Argument #2 ($array) must be of type array, Timber\PostQuery given. Coerce Traversable / Timber\PostQuery to a plain array before calling array_map(). Prevents fatal on woocommerce_after_shop_loop when a PostQuery is passed through. No behavioral change for existing array inputs.

Description
Under PHP 8+, array_map() requires its second argument to be a plain array. In some environments (notably with Timber), $wp_query->posts may be a Traversable or a Timber\PostQuery, which causes:
TypeError: array_map(): Argument #2 ($array) must be of type array, Timber\PostQuery given
This patch adds a small, local coercion step that converts Timber\PostQuery to its underlying array (->posts) or any Traversable to an array via iterator_to_array() before calling array_map(). If neither condition is met, we fall back to an empty array to avoid fatals while preserving current behavior for valid arrays.

Type of change

Fix (non-breaking change which fixes an issue)

Checklist

I have commented my code, particularly in hard-to-understand areas, if any.
I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
I followed general Pull Request best practices. Meta employees to follow this wiki.
I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
I have updated or requested update to plugin documentations (if necessary). Meta employees to follow this wiki.

Changelog entry
Harden events tracker against PHP 8+: coerce iterables to arrays before array_map() to prevent fatal on woocommerce_after_shop_loop.

Test Plan
Environment: PHP 8.3 (also valid for 8.1/8.2), WordPress + WooCommerce latest, Timber 2.x / Twig 3.x (or any setup where $wp_query->posts may be non-array), “Product category” archive page to trigger woocommerce_after_shop_loop.

Steps:

Before patch: Visit a product category archive — observe fatal: TypeError: array_map(): Argument #2 ($array) must be of type array, Timber\PostQuery given.

Apply patch: Replace the block at ~line 211 per diff below.

After patch: Reload the category archive. No fatal; page renders normally. Confirm that view_category event still fires as expected (check browser network requests / pixel helper). Confirm no new PHP warnings or PHPCS issues in logs.

Screenshots
Before: White screen / fatal error shown in logs.
After: Archive page renders; pixel/event fires; no fatal in logs.